### PR TITLE
Removed newline regex rewriting causing a mismatch.

### DIFF
--- a/debug/simplemde.debug.js
+++ b/debug/simplemde.debug.js
@@ -13373,7 +13373,6 @@ inline.gfm = merge({}, inline.normal, {
  */
 
 inline.breaks = merge({}, inline.gfm, {
-  br: replace(inline.br)('{2,}', '*')(),
   text: replace(inline.gfm.text)('{2,}', '*')()
 });
 

--- a/debug/simplemde.js
+++ b/debug/simplemde.js
@@ -13372,7 +13372,6 @@ inline.gfm = merge({}, inline.normal, {
  */
 
 inline.breaks = merge({}, inline.gfm, {
-  br: replace(inline.br)('{2,}', '*')(),
   text: replace(inline.gfm.text)('{2,}', '*')()
 });
 


### PR DESCRIPTION
See case https://github.com/sparksuite/simplemde-markdown-editor/pull/519